### PR TITLE
Fix changelog popup placement

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -66,6 +66,7 @@
         </div>
       </div>
     </main>
+    <div id="modal-overlay" class="modal-overlay" tabindex="-1"></div>
     <!-- Start emojicom.io widget -->
     <script>window.emojicom_widget = { campaign: "oBdOLuhbPYRfIXA3dQbD" };</script>
     <script src="https://cdn.emojicom.io/embed/widget.js" async></script>
@@ -93,7 +94,17 @@
       var HW_config = {
         selector: ".changelog-link", // CSS selector where to inject the badge
         account:  "7wrqWx",
-        trigger: ".changelog-link"
+        trigger: ".changelog-link",
+        callbacks: {
+          onShowWidget: function() {
+            if (getViewportWidth() <= 490) {
+              showModalOverlay();
+            }
+          },
+          onHideWidget: function() {
+            hideModalOverlay();
+          }
+        }
       }
     </script>
     <script async src="https://cdn.headwayapp.co/widget.js"></script>

--- a/landing/index.html
+++ b/landing/index.html
@@ -97,16 +97,6 @@
       }
     </script>
     <script async src="https://cdn.headwayapp.co/widget.js"></script>
-    <style>
-      .changelog-link:after {
-        display: none;
-      }
-
-      #HW_badge_cont {
-        display: inline-block !important;
-        vertical-align: middle;
-      }
-    </style>
     <script src="landing.js"></script>
   </body>
 </html>

--- a/landing/landing.css
+++ b/landing/landing.css
@@ -34,6 +34,29 @@ cite::before {
   opacity: 0.3;
 }
 
+
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 999;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  -webkit-transition: opacity .2s;
+  transition: opacity .2s;
+  pointer-events: none;
+}
+
+.modal-overlay.show {
+  pointer-events: all;
+  opacity: 1;
+}
+
+
+
 main {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -70,6 +93,8 @@ main {
 .half-left-content {
   margin: 0 15px;
 }
+
+
 
 .version-badge {
   display: inline-block;
@@ -174,6 +199,8 @@ main {
   transform: translateX(3px);
   opacity: 1;
 }
+
+
 
 .half.right {
   float: right;
@@ -282,6 +309,8 @@ main {
   font-family: "Source Code Pro", monospace;
   white-space: pre-wrap;
 }
+
+
 
 @media only screen and (max-width: 1045px) {
   main {

--- a/landing/landing.css
+++ b/landing/landing.css
@@ -371,4 +371,8 @@ main {
     bottom: 0 !important;
     width: 100% !important;
   }
+
+  #HW_frame {
+    border-radius: 8px 8px 0 0 !important;
+  }
 }

--- a/landing/landing.css
+++ b/landing/landing.css
@@ -160,6 +160,15 @@ main {
   opacity: 0.85;
 }
 
+#HW_badge_cont {
+  display: inline-block !important;
+  vertical-align: middle;
+}
+
+#HW_frame_cont {
+  left: 50px !important;
+}
+
 .block-link:hover::after, .block-link:focus::after {
   -webkit-transform: translateX(3px);
   transform: translateX(3px);
@@ -322,5 +331,15 @@ main {
     -webkit-box-pack: start;
     -ms-flex-pack: start;
     justify-content: flex-start;
+  }
+}
+
+@media only screen and (max-width: 490px) {
+  #HW_frame_cont {
+    position: fixed !important;
+    left: 0px !important;
+    top: initial !important;
+    bottom: 0 !important;
+    width: 100% !important;
   }
 }

--- a/landing/landing.js
+++ b/landing/landing.js
@@ -1,3 +1,8 @@
+Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+// Based off https://stackoverflow.com/a/8876069/10074924
+var getViewportWidth = function() { return Math.max(document.documentElement.clientWidth, window.innerWidth || 0); }
+
+var modalOverlay = document.getElementById("modal-overlay");
 var embedCode;
 var username;
 var frameWidth, frameHeight;
@@ -7,6 +12,20 @@ var initialEndForm = document.getElementById("end-form");
 var previewFrame = document.getElementById("preview-frame");
 var getCodeEl = document.getElementById("getcode");
 var embedCodeEl = document.getElementById("embed-code");
+
+var showModalOverlay = function() {
+  modalOverlay.className = "modal-overlay show";
+}
+
+var hideModalOverlay = function() {
+  modalOverlay.className = "modal-overlay";
+}
+
+var showChangelogModalOverlay = function() {
+  if (viewportWidth <= 490) {
+    showModalOverlay();
+  }
+}
 
 var startGetCode = function() {
   username = document.getElementById("username-input").value;


### PR DESCRIPTION
Make the changelog popup less to the left on desktop, and a bottom drawer on mobile.

Maybe having an overlay on the rest of the content on mobile when the popup is open ?

What do you think @githubfan @Andreto ?
Please approve the PR if you're okay.
You can test with the deploy preview in the checks below.