### PR TITLE
Add a better (non-default) scrollbar in modern browsers

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,19 @@
   }
 }
 
+body::-webkit-scrollbar {
+  width: 0.8em;
+}
+
+body::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+body::-webkit-scrollbar-thumb {
+  background-color: #262626;
+  border-radius: 100px;
+}
+
 body {
   font-family: "Open Sans", sans-serif;
   margin: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -30,7 +30,7 @@ body::-webkit-scrollbar-track {
 }
 
 body::-webkit-scrollbar-thumb {
-  background-color: #262626;
+  background-color: rgba(0,0,0,0.65);
   border-radius: 100px;
 }
 


### PR DESCRIPTION
This PR uses `::webkit-scrollbar` properties to create a prettier scrollbar for the embed in modern versions of Safari, Chrome, and Firefox (no IE support).